### PR TITLE
install 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,8 +51,27 @@ HOMEPAGE = "https://github.com/ome/omero-figure"
 
 cmdclass = {}
 
+class NpmInstall(Command):
+
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        self.spawn(['npm', 'install', 'grunt-cli'])
+        self.spawn(['npm', 'install'])
+
+
+cmdclass['npm_install'] = NpmInstall
+
 
 class Grunt(Command):
+
+    sub_commands = [
+        ('npm_install', None)
+    ]
 
     def initialize_options(self):
         pass
@@ -63,6 +82,10 @@ class Grunt(Command):
     def run(self):
         if not os.path.isdir('src'):
             return
+
+        for command in self.get_sub_commands():
+            self.run_command(command)
+
         self.spawn(['grunt', 'jst'])
         self.spawn(['grunt', 'concat'])
         self.spawn(['grunt', 'jshint'])


### PR DESCRIPTION
Install ``grunt-cli`` in setup.py

This should install ``grunt-cli`` (not globally) 
The rest should work as before
This means that we should only need to install ``node.js``

To test:

 * uninstall grunt-cli locally
 * delete node_modules directory in omero-figure
 * run python setup.py sdist